### PR TITLE
fix trailing dots in filenames

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -291,7 +291,7 @@ export class DownloaderHelper extends EventEmitter {
                             reject(new Error(`Response status was ${response.statusCode}`));
                         }
                         resolve({
-                            name: this.__getFileNameFromHeaders(response.headers),
+                            name: this.__getFileNameFromHeaders(response.headers, response),
                             total: parseInt(response.headers['content-length'] || 0)
                         });
                     })
@@ -302,7 +302,7 @@ export class DownloaderHelper extends EventEmitter {
                     reject(new Error(`Response status was ${response.statusCode}`));
                 }
                 resolve({
-                    name: this.__getFileNameFromHeaders(response.headers),
+                    name: this.__getFileNameFromHeaders(response.headers, response),
                     total: parseInt(response.headers['content-length'] || 0)
                 });
             });
@@ -609,7 +609,7 @@ export class DownloaderHelper extends EventEmitter {
      * @returns {String}
      * @memberof DownloaderHelper
      */
-    __getFileNameFromHeaders(headers) {
+    __getFileNameFromHeaders(headers, response) {
         let fileName = '';
 
         // Get Filename
@@ -631,7 +631,7 @@ export class DownloaderHelper extends EventEmitter {
 
         return (
             (this.__opts.fileName)
-            ? this.__getFileNameFromOpts(fileName)
+            ? this.__getFileNameFromOpts(fileName, response)
             : fileName
         ).split('.').filter(Boolean).join('.'); // remove any potential trailing '.' (just to be sure)
     }
@@ -671,7 +671,7 @@ export class DownloaderHelper extends EventEmitter {
      * @returns {String}
      * @memberof DownloaderHelper
      */
-    __getFileNameFromOpts(fileName) {
+    __getFileNameFromOpts(fileName, response) {
 
         if (!this.__opts.fileName) {
             return fileName;
@@ -679,7 +679,11 @@ export class DownloaderHelper extends EventEmitter {
             return this.__opts.fileName;
         } else if (typeof this.__opts.fileName === 'function') {
             const currentPath = path.join(this.__destFolder, fileName);
-            return this.__opts.fileName(fileName, currentPath);
+            if ((response && response.headers) || (this.__response && this.__response.headers)) {
+                return this.__opts.fileName(fileName, currentPath, (response ? response : this.__response).headers['content-type']);
+            } else {
+                return this.__opts.fileName(fileName, currentPath);
+            }
         } else if (typeof this.__opts.fileName === 'object') {
 
             const fileNameOpts = this.__opts.fileName;  // { name:string, ext:true|false|string}

--- a/src/index.js
+++ b/src/index.js
@@ -622,12 +622,18 @@ export class DownloaderHelper extends EventEmitter {
             fileName = fileName.replace(new RegExp('"', 'g'), '');
             fileName = fileName.replace(/[/\\]/g, '');
         } else {
-            fileName = path.basename(URL.parse(this.requestURL).pathname);
+            if (path.basename(URL.parse(this.requestURL).pathname).length > 0) {
+                fileName = path.basename(URL.parse(this.requestURL).pathname);
+            } else {
+                fileName = `${URL.parse(this.requestURL).hostname}.html`;
+            }
         }
 
-        return (this.__opts.fileName)
+        return (
+            (this.__opts.fileName)
             ? this.__getFileNameFromOpts(fileName)
-            : fileName;
+            : fileName
+        ).split('.').filter(Boolean).join('.'); // remove any potential trailing '.' (just to be sure)
     }
 
     /**
@@ -689,8 +695,8 @@ export class DownloaderHelper extends EventEmitter {
                 if (ext) {
                     return name;
                 } else {
-                    const _ext = fileName.split('.').pop();
-                    return `${name}.${_ext}`;
+                    const _ext = fileName.includes('.') ? fileName.split('.').pop() : ''; // make sure there is a '.' in the fileName string
+                    return _ext !== '' ? `${name}.${_ext}` : name; // if there is no extension, replace the whole file name
                 }
             }
         }
@@ -861,7 +867,7 @@ export class DownloaderHelper extends EventEmitter {
             let suffix = pathInfo ? parseInt(pathInfo[2].replace(/\(|\)/, '')) : 0;
             let ext = path.split('.').pop();
 
-            if (ext !== path) {
+            if (ext !== path && ext.length > 0) {
                 ext = '.' + ext;
                 base = base.replace(ext, '');
             } else {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -167,5 +167,26 @@ describe('DownloaderHelper', function () {
             const result = dl.__getFileNameFromOpts(fileName);
             expect(result).to.be.equal(newFileName);
         });
+
+        it("should append '.html' to a file if there is no 'content-disposition' header and no 'path'", function () {
+            const newFileName = 'google.html';
+            const dl = new DownloaderHelper('https://google.com/', __dirname, {
+                fileName: { name: newFileName, ext: true }
+            });
+            const result = dl.__getFileNameFromHeaders({
+            });
+            expect(result).to.be.equal(newFileName);
+        });
+
+        it("should *not* append '.html' to a file if there *is* 'content-disposition' header but no 'path'", function () {
+            const newFileName = 'filename.jpg';
+            const dl = new DownloaderHelper('https://google.com/', __dirname, {
+                fileName: { name: newFileName, ext: true }
+            });
+            const result = dl.__getFileNameFromHeaders({
+                'content-disposition': 'Content-Disposition: attachment; filename="'+newFileName+'"',
+            });
+            expect(result).to.be.equal(newFileName);
+        });
     });
 });


### PR DESCRIPTION
- any url without a path will result in a .html file

this closes #27 

I also tried writing a test for it, but I've never used chai and couldn't figure out how to handle promises (because I need to start the download or at least make a request to get the server's response).  
Given that you also didn't test any actual download attempts (or did I miss it?), I've omitted the test, but there's my attempt:

```node
it("should never rename the file to have a trailing dot", function () {
    //TODO TEST ISN'T WORKING!!!
    const newFileName = 'mynewname';

    let resultPromise = new Promise((resolve) => {
        const dl = new DownloaderHelper('https://google.com/', __dirname, {
            // fileName: { name: newFileName, ext: true }
        });
        dl.once('download', (downloadStats) => resolve(downloadStats.fileName))
        dl.start()
    })

    resultPromise.then(function (result) {
        expect(result.split('.').splice(-1)[0].length > 0).to.be.equal(true);
        done();
    })

});
```

I also didn't include the mime-type/content-type stuff because it turns out that it isn't easy to test either (for the same reasons as above).

If you want I could force-push a commit with failing test to my forked repo so you can take a look at them and try to get the tests to work :)