### PR TITLE
Fix leading dots being removed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -654,7 +654,7 @@ export class DownloaderHelper extends EventEmitter {
             (this.__opts.fileName)
                 ? this.__getFileNameFromOpts(fileName, response)
                 : fileName
-        ).split('.').filter(Boolean).join('.'); // remove any potential trailing '.' (just to be sure)
+        ).replace(/\.*$/, ''); // remove any potential trailing '.' (just to be sure)
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -649,12 +649,12 @@ export class DownloaderHelper extends EventEmitter {
                 fileName = `${URL.parse(this.requestURL).hostname}.html`;
             }
         }
-
+        
         return (
             (this.__opts.fileName)
                 ? this.__getFileNameFromOpts(fileName, response)
-                : fileName
-        ).replace(/\.*$/, ''); // remove any potential trailing '.' (just to be sure)
+                : fileName.replace(/\.*$/, '') // remove any potential trailing '.' (just to be sure)
+        )
     }
 
     /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -235,5 +235,17 @@ describe('DownloaderHelper', function () {
             });
             expect(result).to.be.equal(newFileName);
         });
+
+        it("should keep leading dots but remove trailing dots", function () {
+            const newFileName = '.gitignore.';
+            const expectedFileName = '.gitignore';
+            const dl = new DownloaderHelper('https://google.com/', __dirname, {
+                fileName: { name: newFileName, ext: true }
+            });
+            const result = dl.__getFileNameFromHeaders({
+                'content-disposition': 'Content-Disposition: attachment; filename="' + newFileName + '"',
+            });
+            expect(result).to.be.equal(expectedFileName);
+        });
     });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -236,11 +236,23 @@ describe('DownloaderHelper', function () {
             expect(result).to.be.equal(newFileName);
         });
 
-        it("should keep leading dots but remove trailing dots", function () {
+        it("should keep leading dots but remove trailing dots for auto-generated file names", function () {
             const newFileName = '.gitignore.';
             const expectedFileName = '.gitignore';
             const dl = new DownloaderHelper('https://google.com/', __dirname, {
-                fileName: { name: newFileName, ext: true }
+                // fileName: { name: newFileName, ext: true }
+            });
+            const result = dl.__getFileNameFromHeaders({
+                'content-disposition': 'Content-Disposition: attachment; filename="' + newFileName + '"',
+            });
+            expect(result).to.be.equal(expectedFileName);
+        });
+
+        it("should not modify the filename when providing a callback", function () {
+            const newFileName = '.gitignore.';
+            const expectedFileName = newFileName
+            const dl = new DownloaderHelper('https://google.com/', __dirname, {
+                fileName: () => '.gitignore.'
             });
             const result = dl.__getFileNameFromHeaders({
                 'content-disposition': 'Content-Disposition: attachment; filename="' + newFileName + '"',


### PR DESCRIPTION
Switched to a simple RegExp-based approach that works well, with a single or multiple trailing dots.  
Added a test to make sure it works.

- this fixes #58 

I also thought about the option for forcing the provided name without any processing (e.g. `forceFilename: true`), but I think because this can lead to insecure filenames (e.g. trailing dots causing corrupted files on Windows), this shouldn't be so easy to do.  
And if someone really needs this, passing `filename: (forcedName) => forcedName` solves the problem.

If you want me to, I could also mention the above in the readme so people know how to deal with it :)