### PR TITLE
Disable keepalive by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x]
+        node-version: [14.x, 15.x, 16.x, 19.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export class DownloaderHelper extends EventEmitter {
 
         this.url = this.requestURL = url.trim();
         this.state = DH_STATES.IDLE;
+        this.__agent = null;
         this.__defaultOpts = {
             body: null,
             retry: false, // { maxRetries: 3, delay: 3000 }
@@ -284,8 +285,8 @@ export class DownloaderHelper extends EventEmitter {
             this.__opts.progressThrottle = this.__defaultOpts.progressThrottle;
         }
 
-        this.__options = this.__getOptions(this.__opts.method, this.url, this.__opts.headers);
         this.__initProtocol(this.url);
+        this.__options = this.__getOptions(this.__opts.method, this.url, this.__opts.headers);
     }
 
     /**
@@ -958,6 +959,7 @@ export class DownloaderHelper extends EventEmitter {
             port: urlParse.port,
             path: urlParse.pathname + urlParse.search,
             method,
+            agent: this.__agent,
         };
 
         if (headers) {
@@ -1044,9 +1046,11 @@ export class DownloaderHelper extends EventEmitter {
 
         if (url.indexOf('https://') > -1) {
             this.__protocol = https;
+            this.__agent = new https.Agent({ keepAlive: false });
             this.__options = Object.assign({}, defaultOpts, this.__opts.httpsRequestOptions);
         } else {
             this.__protocol = http;
+            this.__agent = new http.Agent({ keepAlive: false });
             this.__options = Object.assign({}, defaultOpts, this.__opts.httpRequestOptions);
         }
 


### PR DESCRIPTION
Node 19 introduces [a new change](https://github.com/nodejs/node/releases/tag/v19.0.0) which makes HTTP requests KeepAlive by default. This has the unintended side effect of making processes hang open, leading to eventual failure.

This change introduces two things:
 - We now disable keepalives by default on requests. This should be a no-op on older releases of Node where the flag does not exist.
 - We now test against Node.19 to protect against breakages in CI.