### PR TITLE
fix: make retry cover errors during headers and during body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -501,9 +501,7 @@ export class DownloaderHelper extends EventEmitter {
                 const err = new Error(`Response status was ${response.statusCode}`);
                 err.status = response.statusCode || 0;
                 err.body = response.body || '';
-                this.__setState(this.__states.FAILED);
-                this.emit('error', err);
-                return reject(err);
+                return this.__onError(resolve, reject)(err);
             }
 
             if (this.__opts.forceResume) {


### PR DESCRIPTION
I believe this fixes one part of the issue in #115 and maybe helps #113 a bit as well, not sure if it entirely closes either but maybe one step closer.

The logic behind it is fairly simple - make the error handling during parsing the resposne be the same as the error handling of the http event listeners, the __onError function already takes care of setting the state to failed when we're out of retries and also emitting the error.